### PR TITLE
refactor: make #merge_into_case method more robust

### DIFF
--- a/lib/hachi/clients/alert.rb
+++ b/lib/hachi/clients/alert.rb
@@ -129,7 +129,7 @@ module Hachi
       #
       def merge_into_case(*ids, case_id)
         params = {
-          alertIds: ids,
+          alertIds: ids.flatten,
           caseId: case_id
         }
         post("/api/alert/merge/_bulk", params) { |json| json }


### PR DESCRIPTION
Enable to pass multi-array as an input